### PR TITLE
Use prepare script to build wasm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "npmluau": "main.js"
   },
   "scripts": {
-    "build": "wasm-pack build luau-types-re-export --target nodejs --release && rm -f luau-types-re-export/pkg/.gitignore",
+    "prepare": "wasm-pack build luau-types-re-export --target nodejs --release && rm -f luau-types-re-export/pkg/.gitignore",
     "test": "cargo test --manifest-path luau-types-re-export/Cargo.toml",
     "lint": "eslint main.js src/",
     "format": "prettier . --write",


### PR DESCRIPTION
This should make the package installable as a git dependency and also making sure that the wasm package is built before publishing