### PR TITLE
Add aliases entry to generated luaurc file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- add a `pkg` alias entry to the generated `.luaurc` file in `node_modules` ([#9](https://github.com/seaofvoices/darklua/pull/9))
+
 ## 0.1.1
 
 - re-export types in nested blocks ([#6](https://github.com/seaofvoices/darklua/pull/6))

--- a/src/createLuauRc.js
+++ b/src/createLuauRc.js
@@ -4,6 +4,7 @@ const path = require('path')
 const NOCHECK_CONFIG = JSON.stringify(
   {
     languageMode: 'nocheck',
+    aliases: { '@pkg': './.luau-aliases' },
   },
   null,
   4

--- a/src/createLuauRc.js
+++ b/src/createLuauRc.js
@@ -4,7 +4,7 @@ const path = require('path')
 const NOCHECK_CONFIG = JSON.stringify(
   {
     languageMode: 'nocheck',
-    aliases: { '@pkg': './.luau-aliases' },
+    aliases: { 'pkg': './.luau-aliases' },
   },
   null,
   4

--- a/src/createLuauRc.js
+++ b/src/createLuauRc.js
@@ -4,7 +4,7 @@ const path = require('path')
 const NOCHECK_CONFIG = JSON.stringify(
   {
     languageMode: 'nocheck',
-    aliases: { 'pkg': './.luau-aliases' },
+    aliases: { pkg: './.luau-aliases' },
   },
   null,
   4


### PR DESCRIPTION
An upcoming feature in darklua (`.luaurc` support in [#246](https://github.com/seaofvoices/darklua/pull/246)) will now remove the need to specify the aliases within the darklua config, and instead only use the `.luaurc` files.

npmluau currently generates a `.luaurc` file in the `node_modules` folder to disable type checking, but it should also set an alias to `@pkg` to the generated `.luau-aliases` folder.

- [x] add entry to the changelog
