### PR TITLE
Omit default type for generic type parameters when re-exporting types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- omit default type for generic type parameters when re-exporting types ([#11](https://github.com/seaofvoices/darklua/pull/11))
 - upgrade to latest full-moon ([#10](https://github.com/seaofvoices/darklua/pull/10))
 - add a `pkg` alias entry to the generated `.luaurc` file in `node_modules` ([#9](https://github.com/seaofvoices/darklua/pull/9))
 

--- a/luau-types-re-export/src/snapshots/luau_types_re_export__tests__export_generic_type_with_unexported_default.snap
+++ b/luau-types-re-export/src/snapshots/luau_types_re_export__tests__export_generic_type_with_unexported_default.snap
@@ -1,0 +1,7 @@
+---
+source: src/lib.rs
+expression: result
+---
+local module = require('../packages/module')
+export type List<T> = module.List<T>
+return module

--- a/luau-types-re-export/src/snapshots/luau_types_re_export__tests__export_simple_generic_type_with_default_simple_array.snap
+++ b/luau-types-re-export/src/snapshots/luau_types_re_export__tests__export_simple_generic_type_with_default_simple_array.snap
@@ -1,0 +1,7 @@
+---
+source: src/lib.rs
+expression: result
+---
+local module = require('../packages/module')
+export type List<T = { number }> = module.List<T>
+return module


### PR DESCRIPTION
Closes #8 

These changes also make a simple "best effort" at preserving certain default types. For example, built-in types (like `string`) are preserved.

```lua
export type Foo<Key = string> = FooImpl<Key>
```

- [x] add entry to the changelog
